### PR TITLE
Update loader for dataset JSON files

### DIFF
--- a/solver/dataset.py
+++ b/solver/dataset.py
@@ -11,30 +11,26 @@ from torch.utils.data import Dataset
 
 
 class ARCDataset(Dataset):
-    """Simple loader for ARC dataset.
+    """Simple loader for the Kaggle ARC-AGI dataset.
 
-    This is a lightweight loader that expects tasks to be stored as JSON files in
-    the following structure::
-
-        dataset_root/
-            train/
-                <task_id>.json
-            test/
-                <task_id>.json
-
-    Each JSON file should contain ``train`` and ``test`` fields with lists of
-    input/output grid pairs.
+    The actual dataset files are provided as JSON mappings in the ``dataset``
+    directory.  Each split (``training``, ``evaluation`` or ``test``) is stored
+    in a single JSON file containing a mapping from task IDs to dictionaries with
+    ``train`` and ``test`` fields.  The ``test`` portion of the ``training`` and
+    ``evaluation`` splits has its ground-truth outputs stored in a companion
+    ``*_solutions.json`` file.
     """
+
+    _SPLIT_FILES = {
+        "training": ("arc-agi_training_challenges.json", "arc-agi_training_solutions.json"),
+        "evaluation": ("arc-agi_evaluation_challenges.json", "arc-agi_evaluation_solutions.json"),
+        "test": ("arc-agi_test_challenges.json", None),
+    }
 
     def __init__(self, root: str | Path, split: str | None = None) -> None:
         self.root = Path(root)
         if not self.root.exists():
             raise FileNotFoundError(f"Dataset path {self.root!s} does not exist")
-
-        if not (self.root / "train").exists() or not (self.root / "test").exists():
-            raise FileNotFoundError(
-                "Dataset must contain 'train/' and 'test/' directories"
-            )
 
         self.split = split
         self.tasks: List[dict] = []
@@ -42,13 +38,38 @@ class ARCDataset(Dataset):
             self.tasks = self._load_split(split)
 
     def _load_split(self, split: str) -> List[dict]:
-        split_path = self.root / split
-        if not split_path.exists():
-            raise FileNotFoundError(f"Split directory {split_path!s} does not exist")
+        if split not in self._SPLIT_FILES:
+            raise ValueError(f"Unknown split '{split}'")
+
+        challenge_file, solution_file = self._SPLIT_FILES[split]
+        challenge_path = self.root / challenge_file
+        if not challenge_path.exists():
+            raise FileNotFoundError(f"Challenge file {challenge_path!s} does not exist")
+
+        with open(challenge_path, "r", encoding="utf-8") as f:
+            challenges = json.load(f)
+
+        solutions = {}
+        if solution_file is not None:
+            solution_path = self.root / solution_file
+            if not solution_path.exists():
+                raise FileNotFoundError(f"Solution file {solution_path!s} does not exist")
+            with open(solution_path, "r", encoding="utf-8") as f:
+                solutions = json.load(f)
+
         tasks = []
-        for json_file in split_path.glob("*.json"):
-            with open(json_file, "r", encoding="utf-8") as f:
-                tasks.append(json.load(f))
+        for task_id, task in challenges.items():
+            train_pairs = task.get("train", [])
+            test_pairs = task.get("test", [])
+
+            # attach solutions if available
+            if solution_file is not None:
+                sols = solutions.get(task_id, [])
+                for pair, sol in zip(test_pairs, sols):
+                    pair["output"] = sol
+
+            tasks.append({"train": train_pairs, "test": test_pairs})
+
         return tasks
 
     def __len__(self) -> int:  # type: ignore[override]
@@ -59,7 +80,10 @@ class ARCDataset(Dataset):
 
         def to_tensor(pair: dict) -> Tuple[torch.Tensor, torch.Tensor]:
             inp = torch.tensor(pair["input"], dtype=torch.long)
-            out = torch.tensor(pair["output"], dtype=torch.long)
+            out_grid = pair.get("output")
+            if out_grid is None:
+                out_grid = [[-1 for _ in row] for row in pair["input"]]
+            out = torch.tensor(out_grid, dtype=torch.long)
             return inp, out
 
         train_pairs = [to_tensor(p) for p in task["train"]]
@@ -68,6 +92,6 @@ class ARCDataset(Dataset):
 
     def load(self) -> Tuple["ARCDataset", "ARCDataset"]:
         """Return train and test splits as :class:`ARCDataset` instances."""
-        train_ds = ARCDataset(self.root, "train")
-        test_ds = ARCDataset(self.root, "test")
-        return train_ds, test_ds
+        train_ds = ARCDataset(self.root, "training")
+        eval_ds = ARCDataset(self.root, "evaluation")
+        return train_ds, eval_ds

--- a/solver/evaluate.py
+++ b/solver/evaluate.py
@@ -9,8 +9,8 @@ from .model import SimpleCNN
 
 
 def evaluate(model: SimpleCNN, dataset_root: str) -> float:
-    _, test_ds = ARCDataset(dataset_root).load()
-    test_loader = DataLoader(test_ds, batch_size=4)
+    eval_ds = ARCDataset(dataset_root, "evaluation")
+    test_loader = DataLoader(eval_ds, batch_size=4)
 
     model.eval()
     correct = 0

--- a/solver/train.py
+++ b/solver/train.py
@@ -10,7 +10,7 @@ from .model import SimpleCNN
 
 
 def train(dataset_root: str, epochs: int = 5) -> SimpleCNN:
-    train_ds, _ = ARCDataset(dataset_root).load()
+    train_ds = ARCDataset(dataset_root, "training")
     # Placeholder dataset transformation
     train_loader = DataLoader(train_ds, batch_size=4, shuffle=True)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -14,33 +14,33 @@ class TestDataset(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             ARCDataset(tmp_path)
 
-    def test_missing_split_dirs(self) -> None:
+    def test_missing_split_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            (root / "train").mkdir()
             with self.assertRaises(FileNotFoundError):
-                ARCDataset(root)
+                ARCDataset(root, "training")
 
     def test_loading_and_access(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            (root / "train").mkdir()
-            (root / "test").mkdir()
 
-            data = {
-                "train": [{"input": [[0]], "output": [[1]]}],
-                "test": [{"input": [[2]], "output": [[3]]}],
+            challenges = {
+                "0000": {
+                    "train": [{"input": [[0]], "output": [[1]]}],
+                    "test": [{"input": [[2]]}],
+                }
             }
-            with open(root / "train" / "task.json", "w", encoding="utf-8") as f:
-                json.dump(data, f)
-            with open(root / "test" / "task.json", "w", encoding="utf-8") as f:
-                json.dump(data, f)
+            solutions = {"0000": [[[3]]]} 
 
-            train_ds, test_ds = ARCDataset(root).load()
-            self.assertEqual(len(train_ds), 1)
-            self.assertEqual(len(test_ds), 1)
+            with open(root / "arc-agi_training_challenges.json", "w", encoding="utf-8") as f:
+                json.dump(challenges, f)
+            with open(root / "arc-agi_training_solutions.json", "w", encoding="utf-8") as f:
+                json.dump(solutions, f)
 
-            item = train_ds[0]
+            ds = ARCDataset(root, "training")
+            self.assertEqual(len(ds), 1)
+
+            item = ds[0]
             self.assertIsInstance(item["train"][0][0], torch.Tensor)
 
 


### PR DESCRIPTION
## Summary
- update `ARCDataset` to read dataset JSON files directly
- load training and evaluation splits appropriately
- adjust training/evaluation utilities to use new splits
- update dataset tests for new JSON-based format

## Testing
- `python -m unittest tests.test_dataset -v`